### PR TITLE
fix: preserve Draw.io labels

### DIFF
--- a/src/ibmdiagrams/ibmbase/types.py
+++ b/src/ibmdiagrams/ibmbase/types.py
@@ -510,14 +510,6 @@ class Types:
         parentid = node["parentid"]
         parentid = "1" if parentid is None else parentid
 
-        labelsize = 20
-
-        if len(name) > 0:
-            name = self.common.truncateText(name, labelsize, "<br>")
-
-        if len(subname) > 0:
-            subname = self.common.truncateText(subname, labelsize, "<br>")
-
         if genflag:
             shapelabel = "<b style='font-weight:600'>" + genname
             # shapelabel = genname
@@ -631,14 +623,6 @@ class Types:
             styleIcon = "icon=" + icon + ";" if icon != "" else ""
             style = style.replace("%ICON", styleIcon)
 
-        labelsize = 20
-
-        if len(name) > 0:
-            name = self.common.truncateText(name, labelsize, "<br>")
-
-        if len(subname) > 0:
-            subname = self.common.truncateText(subname, labelsize, "<br>")
-
         if genflag:
             shapelabel = "<b style='font-weight:600'>" + genname
         else:
@@ -668,8 +652,6 @@ class Types:
         return data
 
     def buildDrawioShape(self, id, node, x, y, width, height, meta, genflag):
-        # labelsize = 20
-        labelsize = 15
         shape = node["shape"].lower()
         name = node["label"]
         subname = node["sublabel"]
@@ -681,12 +663,6 @@ class Types:
             linecount = linecount + 1 + name.count("<br")
         if len(subname) > 0:
             linecount = linecount + 1 + subname.count("<br")
-
-        if len(name) > 0:
-            name = self.common.truncateText(name, labelsize, "<br>")
-
-        if len(subname) > 0:
-            subname = self.common.truncateText(subname, labelsize, "<br>")
 
         if genflag:
             shapelabel = "<b style='font-weight:600'>" + genname

--- a/tests/test_drawio_labels.py
+++ b/tests/test_drawio_labels.py
@@ -1,0 +1,24 @@
+"""Regression tests for DrawIO label rendering."""
+
+from pathlib import Path
+
+from ibmdiagrams.ibmcloud.compute import VirtualServer
+from ibmdiagrams.ibmcloud.diagram import Diagram
+from ibmdiagrams.ibmcloud.groups import VPC, IBMCloud, Region, Subnet, Zone
+
+
+def test_drawio_labels_are_not_truncated(tmp_path: Path):
+    with Diagram("long-labels", output=str(tmp_path)):
+        with IBMCloud("IBM Cloud with a long name"):
+            with Region("Dallas"):
+                with VPC("My Production VPC with a long name"):
+                    with Zone("Zone 1", "10.10.0.0/18"):
+                        with Subnet("App Subnet", "10.10.10.0/24"):
+                            VirtualServer("Web Server", "10.10.10.4")
+
+    drawio = (tmp_path / "long-labels.drawio").read_text(encoding="utf-8")
+
+    assert "IBM Cloud with a long name" in drawio
+    assert "My Production VPC with a long name" in drawio
+    assert "IBM Cloud with..." not in drawio
+    assert "My Production ..." not in drawio


### PR DESCRIPTION
# Description

Stop truncating labels before they are written to Draw.io cells. Draw.io can render and wrap the complete label itself, so the fixed 15/20-character limits were discarding user text in generated diagrams.

A regression test generates the issue example and verifies that both long labels remain intact in the `.drawio` output.

## Linked Issue(s)

Fixes #11

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `.\.venv\Scripts\python.exe -m pytest tests\test_drawio_labels.py -q`
- [x] `.\.venv\Scripts\python.exe -m ruff check src\ibmdiagrams\ibmbase\types.py tests\test_drawio_labels.py`
- [x] `.\.venv\Scripts\python.exe -m ruff format --check src\ibmdiagrams\ibmbase\types.py tests\test_drawio_labels.py`

**Test Configuration**:
* Python version: 3.11.9
* ibmdiagrams version: local 3.3.2 checkout
* Installation method: editable pip install
* Input type tested: Python API / Draw.io output
* draw.io desktop version, if visual tests were run: Not run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] The focused unit test passes locally with my changes
- [ ] Full visual regression suite (requires baseline files whose `:` names cannot be checked out on Windows)